### PR TITLE
11.36am: Fix #5041 - C error when cloning array slice

### DIFF
--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -492,6 +492,7 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		kind: .any
 		name: 'T'
 		mod: 'builtin'
+		is_public: true
 	})
 	t.register_type_symbol({
 		kind: .any_float
@@ -610,7 +611,7 @@ pub mut:
 
 pub struct Enum {
 pub:
-	vals []string
+	vals    []string
 	is_flag bool
 }
 

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -38,6 +38,21 @@ fn test_foo() {
 	assert sum<int>(b) == 6
 }
 
+fn create<T>() {
+	a := T{}
+}
+
+struct User {
+}
+
+struct City {
+}
+
+fn test_create() {
+	create<User>()
+	create<City>()
+}
+
 /*
 fn map_f<T,U>(l []T, f fn(T)U) []U {
     mut r := []U{}

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -169,4 +169,32 @@ fn test_generic_struct() {
 	assert a.model.name == 'joe'
 	assert b.model.name == 'joe'
 }
+
+//
+
+struct Abc{ x int y int z int }
+
+fn p<T>(args ...T) {
+	size:=sizeof(T)
+	print('p called with size: ${size:3d} | ')
+	for _,x in args {
+		print(x)
+		print(' ')
+	}
+	println('')
+	assert true
+}
+
+fn test_generic_fn_with_variadics(){
+	s:='abc'
+	i:=1
+	abc:=Abc{1,2,3}
+	// these calls should all compile, and print the arguments,
+	// even though the arguments are all a different type and arity:
+	p(s)
+	p(i)
+	p(abc)
+	p('Good','morning','world')
+}
+
 */

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -36,14 +36,15 @@ pub const (
 )
 
 pub struct Context {
+mut:
 	static_files map[string]string
 	static_mime_types map[string]string
 pub:
 	req http.Request
 	conn net.Socket
-	form map[string]string
 	// TODO Response
 pub mut:
+	form map[string]string
 	headers string // response headers
 	done bool
 }


### PR DESCRIPTION
When we clone a slice, we get a compile time error while compiling the generated C code. Because
```
a := [1, 2, 3, 4]
b := a[1..].clone()
```
is translated into
```
b = array_clone(&array_slice(...))
```
and we can't take address of only lvalue.
The fix changes the following into
```
b = array_clone_static(array_slice(...))
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
Test Cases:

```
fn test_slice_clone() {
	arr := [1, 2, 3, 4, 5]
	cl := arr[1..].clone()
	assert cl == [2, 3, 4, 5]
}

fn test_slice_clone2() {
	arr := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
	cl := arr[1..].clone()[2..].clone()
	assert cl == [4, 5, 6, 7, 8, 9, 10]
}
```
